### PR TITLE
chore: Deprecate java-openliberty-gradle stack after 365 days of inactivity

### DIFF
--- a/stacks/java-openliberty-gradle/devfile.yaml
+++ b/stacks/java-openliberty-gradle/devfile.yaml
@@ -1,29 +1,14 @@
-# Copyright (c) 2021,2022 IBM Corporation and others
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 schemaVersion: 2.1.0
 metadata:
   name: java-openliberty-gradle
   displayName: Open Liberty Gradle
-  description: Java application based on Java 11, Gradle using the Open Liberty runtime 22.0.0.1
+  description: Java application based on Java 11, Gradle using the Open Liberty runtime
+    22.0.0.1
   icon: https://raw.githubusercontent.com/OpenLiberty/logos/7fbb132949b9b2589e18c8d5665c1b107028a21d/logomark/svg/OL_logomark.svg
   tags:
     - Java
     - Gradle
+    - Deprecated
   architectures:
     - amd64
     - ppc64le
@@ -37,16 +22,18 @@ starterProjects:
   - name: rest
     git:
       remotes:
-        origin: 'https://github.com/OpenLiberty/devfile-stack-starters.git'
+        origin: https://github.com/OpenLiberty/devfile-stack-starters.git
 variables:
-  # Liberty runtime version. Minimum recommended: 21.0.0.9
-  liberty-version: '22.0.0.1'
-  gradle-cmd: 'gradle'
+  liberty-version: 22.0.0.1
+  gradle-cmd: gradle
 components:
   - name: dev
     container:
       image: icr.io/appcafe/open-liberty-devfile-stack:{{liberty-version}}-gradle
-      args: ['tail', '-f', '/dev/null']
+      args:
+        - tail
+        - -f
+        - /dev/null
       memoryLimit: 1280Mi
       mountSources: true
       endpoints:
@@ -65,7 +52,9 @@ commands:
   - id: run
     exec:
       component: dev
-      commandLine: echo "gradle run command"; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty --libertyDebug=false --hotTests --compileWait=3
+      commandLine: echo "gradle run command"; {{gradle-cmd}} -Dgradle.user.home=/.gradle
+        libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime
+        -Pliberty.runtime.group=io.openliberty --libertyDebug=false --hotTests --compileWait=3
       workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
@@ -74,7 +63,9 @@ commands:
   - id: run-test-off
     exec:
       component: dev
-      commandLine: echo "gradle run-tests-off command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty --libertyDebug=false
+      commandLine: echo "gradle run-tests-off command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle
+        libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime
+        -Pliberty.runtime.group=io.openliberty --libertyDebug=false
       workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
@@ -83,7 +74,9 @@ commands:
   - id: debug
     exec:
       component: dev
-      commandLine: echo "gradle debug command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty --libertyDebugPort=${DEBUG_PORT} -Pliberty.server.env.WLP_DEBUG_REMOTE=y
+      commandLine: echo "gradle debug command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle
+        libertyDev -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime
+        -Pliberty.runtime.group=io.openliberty --libertyDebugPort=${DEBUG_PORT} -Pliberty.server.env.WLP_DEBUG_REMOTE=y
       workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:
@@ -92,7 +85,9 @@ commands:
   - id: test
     exec:
       component: dev
-      commandLine: echo "gradle test command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle test -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime -Pliberty.runtime.group=io.openliberty
+      commandLine: echo "gradle test command "; {{gradle-cmd}} -Dgradle.user.home=/.gradle
+        test -Pliberty.runtime.version={{liberty-version}} -Pliberty.runtime.name=openliberty-runtime
+        -Pliberty.runtime.group=io.openliberty
       workingDir: ${PROJECT_SOURCE}
       hotReloadCapable: true
       group:


### PR DESCRIPTION
## What this PR does?

This PR deprecates the java-openliberty-gradle stack as it has reached the inactivity limit of 365 days.