### PR TITLE
chore: Deprecate nodejs/2.2.0 stack after 365 days of inactivity

### DIFF
--- a/stacks/nodejs/2.2.0/devfile.yaml
+++ b/stacks/nodejs/2.2.0/devfile.yaml
@@ -8,6 +8,7 @@ metadata:
     - Node.js
     - Express
     - ubi8
+    - Deprecated
   projectType: Node.js
   language: JavaScript
   version: 2.2.0
@@ -15,12 +16,15 @@ starterProjects:
   - name: nodejs-starter
     git:
       remotes:
-        origin: 'https://github.com/odo-devfiles/nodejs-ex.git'
+        origin: https://github.com/odo-devfiles/nodejs-ex.git
 components:
   - name: runtime
     container:
       image: registry.access.redhat.com/ubi8/nodejs-18:1-32
-      args: ['tail', '-f', '/dev/null']
+      args:
+        - tail
+        - -f
+        - /dev/null
       memoryLimit: 1024Mi
       mountSources: true
       env:


### PR DESCRIPTION
## What this PR does?

This PR deprecates the nodejs/2.2.0 stack as it has reached the inactivity limit of 365 days.