### PR TITLE
chore: Deprecate php-laravel/2.0.0 stack after 365 days of inactivity

### DIFF
--- a/stacks/php-laravel/2.0.0/devfile.yaml
+++ b/stacks/php-laravel/2.0.0/devfile.yaml
@@ -2,15 +2,13 @@ schemaVersion: 2.2.0
 metadata:
   name: php-laravel
   displayName: Laravel
-  description: "Laravel is an open-source PHP framework, which is robust and easy to understand.
-    It follows a model-view-controller design pattern.
-    Laravel reuses the existing components of different frameworks which helps in creating a web application.
-    The web application thus designed is more structured and pragmatic."
+  description: "Laravel is an open-source PHP framework, which is robust and easy to understand. It follows a model-view-controller design pattern. Laravel reuses the existing components of different frameworks which helps in creating a web application. The web application thus designed is more structured and pragmatic."
   icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/laravel.svg
   tags:
     - PHP
     - Composer
     - Laravel
+    - Deprecated
   projectType: Laravel
   language: PHP
   provider: Red Hat


### PR DESCRIPTION
## What this PR does?

This PR deprecates the php-laravel/2.0.0 stack as it has reached the inactivity limit of 365 days.