### PR TITLE
chore: Deprecate java-openliberty-gradle stack after 365 days of inactivity

### DIFF
--- a/stacks/java-openliberty-gradle/devfile.yaml
+++ b/stacks/java-openliberty-gradle/devfile.yaml
@@ -24,6 +24,7 @@ metadata:
   tags:
     - Java
     - Gradle
+    - Deprecated
   architectures:
     - amd64
     - ppc64le


### PR DESCRIPTION
## What this PR does?

This PR deprecates the java-openliberty-gradle stack as it has reached the inactivity limit of 365 days.