### PR TITLE
chore: Deprecate java-websphereliberty stack after 365 days of inactivity

### DIFF
--- a/stacks/java-websphereliberty/devfile.yaml
+++ b/stacks/java-websphereliberty/devfile.yaml
@@ -25,6 +25,7 @@ metadata:
     - Java
     - Maven
     - WebSphere Liberty
+    - Deprecated
   architectures:
     - amd64
     - ppc64le


### PR DESCRIPTION
## What this PR does?

This PR deprecates the java-websphereliberty stack as it has reached the inactivity limit of 365 days.